### PR TITLE
build(database): upgrade Postgres to version 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you encounter deprecation warnings on newer versions, you may need to downgra
 
 ### PostgreSQL
 
-Postgresql 12 is the minimum version required. You can check your version by running `psql --version`.
+Postgresql 13 is the minimum version required. You can check your version by running `psql --version`.
 
 If you are running the project without Docker, you may need to install and configure PostgreSQL manually. The default configuration file is `docker-compose.env.yaml`, which you may need to adjust for your local setup.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:12
+    image: postgres:13
     restart: on-failure
     environment:
       POSTGRES_USER: notification_service
@@ -11,7 +11,7 @@ services:
     #        networks:
     #            - helsinki
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql@13/data
     container_name: notification_service-db
 
   keycloak:

--- a/docs/development-without-docker.md
+++ b/docs/development-without-docker.md
@@ -6,7 +6,7 @@ Please refer to the [main README](/README.md) for the latest instructions.
 
 Prerequisites:
 
-- PostgreSQL 12
+- PostgreSQL 13
 - Python 3.11
 - Keycloak
 


### PR DESCRIPTION
NS-13.

NOTE: This PR needs this pipeline change to be applied: https://dev.azure.com/City-of-Helsinki/kuva-notification-service-api/_git/kuva-notification-service-api-pipelines/pullrequest/9863. It sets the pipeline and public environments to use the Postgres 13.

NOTE: This PR is based on NS-11-upgrade-deps (not master).