### PR TITLE
NS-11 | fix: cache directory permission errors when running ruff & pytest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,11 @@ COPY --chown=default:root . /app/
 RUN pip install --no-cache-dir -r /app/requirements-dev.txt && \
     git config --system --add safe.directory /app
 
+# Set permissions for cache directories
+RUN mkdir -p /app/.pytest_cache /app/.ruff_cache && \
+    chown -R default:root /app/.pytest_cache /app/.ruff_cache && \
+    chmod -R a+rwx /app/.pytest_cache /app/.ruff_cache
+
 USER default
 EXPOSE 8081/tcp
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,10 @@ services:
       - docker-compose.env.yaml
     volumes:
       - djangodata:/app
+      # Prevent sharing the following directories between host and container
+      # to avoid ownership and/or platform issues:
+      - /app/.ruff_cache
+      - /app/.pytest_cache
     #        networks:
     #            - helsinki
     ports:


### PR DESCRIPTION
## Description

### fix: cache directory permission errors when running ruff & pytest

tested with Windows 11 + Docker Desktop + WSL2 using
"docker compose up --build" +
"docker exec -it notification_service-api bash"

before this PR:
```bash
(app-root) bash-5.1$ ruff format
error: Failed to initialize cache at /app/.ruff_cache: Permission denied
(os error 13)
ruff failed
  Cause: Failed to create temporary file
  Cause: No such file or directory (os error 2) at path
  "/app/.ruff_cache/0.7.0/.tmp6gIgNI"
(app-root) bash-5.1$ pytest . -vv
...
========================================================== warnings s...
../opt/app-root/lib64/python3.11/site-packages/_pytest/cacheprovider....
/opt/app-root/lib64/python3.11/site-packages/_pytest/cacheprovider.py:
451: PytestCacheWarning: could not create cache path /app/.pytest_cache/
v/cache/nodeids: [Errno 13] Permission denied: '/app/.pytest_cache'
	config.cache.set("cache/nodeids", sorted(self.cached_nodeids))

../opt/app-root/lib64/python3.11/site-packages/_pytest/stepwise.py:56
  /opt/app-root/lib64/python3.11/site-packages/_pytest/stepwise.py:56:
  PytestCacheWarning: could not create cache path /app/.pytest_cache/v/
  cache/stepwise: [Errno 13] Permission denied: '/app/.pytest_cache'
	session.config.cache.set(STEPWISE_CACHE_DIR, [])
```

after this PR:
```bash
$ docker exec -it notification_service-api bash
(app-root) bash-5.1$ ruff format
39 files left unchanged
(app-root) bash-5.1$ ruff check
All checks passed!
(app-root) bash-5.1$ pytest . -vv
========================================================================
platform linux -- Python 3.11.7, pytest-7.4.3, pluggy-1.3.0 -- /opt/app-
cachedir: .pytest_cache
django: version: 4.2.7, settings: notification_service.settings (from in
...
========================================================================
4 snapshots passed.
========================================================================
(app-root) bash-5.1$

```

refs NS-11

## Related

[NS-11](https://helsinkisolutionoffice.atlassian.net/browse/NS-11)

[NS-11]: https://helsinkisolutionoffice.atlassian.net/browse/NS-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ