### PR TITLE
feat: install and configure django-csp

### DIFF
--- a/notification_service/constants.py
+++ b/notification_service/constants.py
@@ -1,0 +1,11 @@
+class CSP:
+    """The “special” source values of 'self', 'unsafe-inline', 'unsafe-eval', 'none'
+    and hash-source ('sha256-...') must be quoted! e.g.: CSP_DEFAULT_SRC = ("'self'",).
+    Without quotes they will not work as intended.
+    Ref. https://django-csp.readthedocs.io/en/stable/configuration.html.
+    """
+
+    SELF = "'self'"
+    NONE = "'none'"
+    UNSAFE_INLINE = "'unsafe-inline'"
+    UNSAFE_EVAL = "'unsafe-eval'"

--- a/notification_service/settings.py
+++ b/notification_service/settings.py
@@ -7,6 +7,8 @@ import sentry_sdk
 from django.utils.translation import gettext_lazy as _
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from notification_service.constants import CSP
+
 checkout_dir = environ.Path(__file__) - 2
 assert os.path.exists(checkout_dir("manage.py"))
 
@@ -109,6 +111,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "rest_framework.authtoken",
     "corsheaders",
+    "csp",
     "axes",
     "health_check",
     # local apps under this line
@@ -123,6 +126,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
+    "csp.middleware.CSPMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -151,6 +155,12 @@ TEMPLATES = [
 
 CORS_ORIGIN_WHITELIST = env.list("CORS_ORIGIN_WHITELIST")
 CORS_ORIGIN_ALLOW_ALL = env.bool("CORS_ORIGIN_ALLOW_ALL")
+
+# Configure the default CSP rule for different source types
+CSP_DEFAULT_SRC = [CSP.SELF]
+# NOTE: CSP_STYLE_SRC="'unsafe-inline'" is needed for the inline styles that are added
+# by the `django-helusers` to the base_admin_site.html
+CSP_STYLE_SRC = [CSP.SELF, CSP.UNSAFE_INLINE]
 
 AUTHENTICATION_BACKENDS = [
     "helusers.tunnistamo_oidc.TunnistamoOIDCAuth",

--- a/notification_service/tests/test_csp.py
+++ b/notification_service/tests/test_csp.py
@@ -1,0 +1,26 @@
+import pytest
+from django.test import Client
+
+
+@pytest.fixture
+def client():
+    """Pytest fixture to provide a Django test client."""
+    return Client()
+
+
+def test_csp_header_present(client):
+    """Test that the Content-Security-Policy header is present."""
+    response = client.get("/")
+    assert "Content-Security-Policy" in response.headers
+
+
+def test_csp_header_content(client):
+    """Test that the CSP header has the expected directives."""
+    response = client.get("/")
+    csp_header = response.headers["Content-Security-Policy"]
+    # Adjust assertions based on your actual CSP configuration
+    assert "default-src 'self'" in csp_header
+    # The style-src needs 'unsafe-inline', because the django-helusers
+    # adds some inline styles when it overrides
+    # the default django admin base site template.
+    assert "style-src 'self' 'unsafe-inline'" in csp_header

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 django
 django-cors-headers
+django-csp
 django-environ
 django-helusers
 django-health-check

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ django==5.1.2
     #   -r requirements.in
     #   django-axes
     #   django-cors-headers
+    #   django-csp
     #   django-health-check
     #   django-helusers
     #   djangorestframework
@@ -40,6 +41,8 @@ django==5.1.2
 django-axes==7.0.0
     # via -r requirements.in
 django-cors-headers==4.5.0
+    # via -r requirements.in
+django-csp==3.8
     # via -r requirements.in
 django-environ==0.11.2
     # via -r requirements.in


### PR DESCRIPTION
NS-27.

Install django-CSP. Configure the Content Security Policy so that only the 'self' is allowed, which means only the static content from the domain itself.

The inline styles added by the django-helusers to the Django admin site also needs to be approved with "unsafe-inline".