### PR TITLE
ci: remove mailer cronjobs from uwsgi

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -9,6 +9,3 @@ gid = appuser
 master = 1
 processes = 2
 threads = 2
-cron = -1 -1 -1 -1 -1 /app/manage.py send_mail
-cron = -20 -1 -1 -1 -1 /app/manage.py retry_deferred
-cron = 0 0 -1 -1 -1 /app/manage.py purge_mail_log 7


### PR DESCRIPTION
NS-162.

The django-mailer is no longer installed, so the cronjobs are not needed either.