### PR TITLE
feat: validate input of send message and filter invalid phone numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ NOTE: You have to create API client user first, by login to Django Admin interfa
 
 ## API Documentation
 
+### Phone Number Processing
+
+This application provides tools for validating and formatting phone numbers using the [phonenumberslite](https://pypi.org/project/phonenumberslite/) library. It's designed to handle a variety of phone number formats and ensure accurate processing.
+
+Features:
+
+- **Phone Number Validation:** Accurately validates phone numbers using the `phonenumberslite` library, ensuring they are in a valid format and potentially even checking their reachability. The phone number parser region is set to "FI".
+- **Invalid Number Filtering:** Identifies and filters out invalid phone numbers, including those with invalid characters or formats.
+- **Letter Filtering:** Specifically handles and rejects phone numbers containing letters to prevent unintended conversions.
+- **Internationalization:** Converts phone numbers to international format for consistency and global compatibility.
+- **Error Handling:** Includes robust error handling to gracefully manage invalid input and provide informative logging for debugging.
+
+> The phone numbers that are set as destination but are not valid, are filtered out from the list of recipients.
+
 ### TODO: FIXME!
 
 - [Swagger Hub](https://app.swaggerhub.com/apis-docs/t0mim/NotificationService/1.0.1)
@@ -213,9 +227,11 @@ This project uses [`ruff`](https://docs.astral.sh/ruff/formatter/) for Python co
 `ruff format` is the primary entrypoint to the formatter. It accepts a list of files or directories, and formats all discovered Python files:
 
 ```
-ruff format                   # Format all files in the current directory.
-ruff format path/to/code/     # Format all files in `path/to/code` (and any subdirectories).
-ruff format path/to/file.py   # Format a single file.
+
+ruff format # Format all files in the current directory.
+ruff format path/to/code/ # Format all files in `path/to/code` (and any subdirectories).
+ruff format path/to/file.py # Format a single file.
+
 ```
 
 > Similar to Black, running ruff format /path/to/file.py will format the given file or directory in-place, while ruff format --check /path/to/file.py will avoid writing any formatted files back, and instead exit with a non-zero status code upon detecting any unformatted files.
@@ -225,10 +241,12 @@ To run the Ruff Linter use `ruff check`.
 > `ruff check` is the primary entrypoint to the Ruff linter. It accepts a list of files or directories, and lints all discovered Python files, optionally fixing any fixable errors:
 
 ```
-ruff check                  # Lint all files in the current directory.
-ruff check --fix            # Lint all files in the current directory, and fix any fixable errors.
-ruff check --watch          # Lint all files in the current directory, and re-lint on change.
-ruff check path/to/code/    # Lint all files in `path/to/code` (and any subdirectories).
+
+ruff check # Lint all files in the current directory.
+ruff check --fix # Lint all files in the current directory, and fix any fixable errors.
+ruff check --watch # Lint all files in the current directory, and re-lint on change.
+ruff check path/to/code/ # Lint all files in `path/to/code` (and any subdirectories).
+
 ```
 
 1. Install `pre-commit` (there are many ways to do but let's use pip as an example):
@@ -305,3 +323,7 @@ There's also a CLI for debugging and manually running releases available for rel
 When a Release-Please pull request is merged and a version tag is created (or a proper tag name for a commit is manually created), this tag will be picked by Azure pipeline, which then triggers a new deployment to staging. From there, the deployment needs to be manually approved to allow it to proceed to the production environment.
 
 The tag name is defined in the [azure-pipelines-notification-service-api-release.yml](./azure-pipelines-notification-service-api-release.yml).
+
+```
+
+```

--- a/api/const.py
+++ b/api/const.py
@@ -1,1 +1,2 @@
 NOTIFICATION_TYPE_MOBILE = "mobile"
+REGION = "FI"

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -1,0 +1,177 @@
+import pytest
+
+from api.utils import filter_valid_destinations, validate_send_message_payload
+
+REGION_FI_VALID_PHONE_NUMBERS = [
+    "+358 40 123 4567",
+    "00358 40 123 4567",
+    "+358 50 123 4567",
+    "+358 5 0 1 2 3 4 5 6 7",
+    "+358 5 0 123 4 56 7",
+    "040 123 4567",
+    "041 123 4567",
+    "050 123 4567",
+    "0 5  0 123 4 5 6 7",
+    "(09) 10 12345",
+    "+12124567890",
+    "+12124567890",
+    "+1 212.456.7890",
+    # Randomly generated numbers with
+    # https://www.random-name-generator.com/finland-phone-number-generator.
+    "045 50071",
+    "+3584550071",
+    "018 835339",
+    "06 47893819",
+    "08 6700313",
+    "05 8802237",
+    "02 390141",
+    "+3582390141",
+    "09 1049703",
+    "+35891049703",
+    "03 11481210",
+    "+358311481210",
+    "+492511793147",
+    "+46806519853",
+    "+4567044733",
+    "004567044733",
+    "+004567044733",  # international call prefix
+]
+
+INVALID_PHONE_NUMBERS = [
+    None,
+    "",
+    "invalid",
+    "12345",
+    "011 390141",  # Invalid area code (011), 9 digits
+    "012 123 4567",  # Invalid area code (012), 10 digits
+    "00004567044733",  # Invalid country code 00
+    "00456x7044733",  # Invalid character "x"
+    "040 def ghij",  # Valid for phonenumbers-lib, but invalid because alpha chars
+]
+
+
+def test_validate_send_message_payload_valid_data():
+    """Test with valid data."""
+    data = {
+        "sender": "Hel.fi",
+        "to": [{"destination": "string", "format": "MOBILE"}],
+        "text": "SMS message",
+    }
+    validate_send_message_payload(data)  # No exception should be raised
+
+
+def test_validate_send_message_payload_missing_keys():
+    """Test with missing keys."""
+    data = {"sender": "Hel.fi", "to": [{"destination": "string"}]}
+    with pytest.raises(ValueError) as excinfo:
+        validate_send_message_payload(data)
+    assert (
+        excinfo.value.args[0]
+        == "Missing required keys: 'sender', 'to', and 'text' are required."
+    )
+
+
+def test_validate_send_message_payload_invalid_sender_type():
+    """Test with invalid sender type."""
+    data = {
+        "sender": 123,  # Invalid sender type
+        "to": [{"destination": "string"}],
+        "text": "SMS message",
+    }
+    with pytest.raises(ValueError) as excinfo:
+        validate_send_message_payload(data)
+    assert excinfo.value.args[0] == "'Sender' must be a string"
+
+
+def test_validate_send_message_payload_invalid_to_type():
+    """Test with invalid 'to' field type."""
+    data = {"sender": "Hel.fi", "to": "invalid", "text": "SMS message"}
+    with pytest.raises(ValueError) as excinfo:
+        validate_send_message_payload(data)
+    assert (
+        excinfo.value.args[0]
+        == "'To' must be a list of dictionaries, each with a string 'destination' field."  # noqa
+    )
+
+
+def test_validate_send_message_payload_invalid_to_item_type():
+    """Test with invalid item type in 'to' field."""
+    data = {"sender": "Hel.fi", "to": [123], "text": "SMS message"}
+    with pytest.raises(ValueError) as excinfo:
+        validate_send_message_payload(data)
+    assert (
+        excinfo.value.args[0]
+        == "'To' must be a list of dictionaries, each with a string 'destination' field."  # noqa
+    )
+
+
+def test_validate_send_message_payload_missing_destination_in_to():
+    """Test with missing 'destination' in a 'to' item."""
+    data = {"sender": "Hel.fi", "to": [{"format": "MOBILE"}], "text": "SMS message"}
+    with pytest.raises(ValueError) as excinfo:
+        validate_send_message_payload(data)
+    assert (
+        excinfo.value.args[0]
+        == "'To' must be a list of dictionaries, each with a string 'destination' field."  # noqa
+    )
+
+
+def test_validate_send_message_payload_invalid_text_type():
+    """Test with invalid text type."""
+    data = {
+        "sender": "Hel.fi",
+        "to": [{"destination": "string"}],
+        "text": 123,  # Invalid text type
+    }
+    with pytest.raises(ValueError) as excinfo:
+        validate_send_message_payload(data)
+    assert excinfo.value.args[0] == "'Text' must be a string"
+
+
+def test_filter_valid_destinations_valid_numbers():
+    """Test with valid phone numbers."""
+    destinations = [
+        "+358501234567",
+        "0401234567",  # Assuming REGION is set appropriately
+    ]
+    valid_numbers = filter_valid_destinations(destinations)
+    assert len(valid_numbers) == len(destinations) == 2
+
+
+@pytest.mark.parametrize("phone_number", REGION_FI_VALID_PHONE_NUMBERS)
+def test_filter_valid_destinations_different_valid_formats(phone_number):
+    assert filter_valid_destinations([phone_number])
+
+
+@pytest.mark.parametrize("phone_number", INVALID_PHONE_NUMBERS)
+def test_filter_valid_destinations_invalid_number(phone_number):
+    """Test with invalid phone number."""
+    assert filter_valid_destinations([phone_number]) == []
+
+
+def test_filter_valid_destinations_invalid_numbers():
+    """Test with more than one invalid phone numbers."""
+    valid_numbers = filter_valid_destinations(INVALID_PHONE_NUMBERS)
+    assert len(valid_numbers) == 0  # No valid numbers
+
+
+def test_filter_valid_destinations_mixed_numbers():
+    """Test with a mix of valid and invalid phone numbers."""
+    destinations = [
+        "+358501234567",
+        "invalid",
+        "0401234567",
+    ]
+    valid_numbers = filter_valid_destinations(destinations)
+    assert len(valid_numbers) == 2
+
+
+def test_filter_valid_destinations_international_format():
+    """Test with convert_to_international_format=True."""
+    destinations = ["0401234567"]
+    valid_numbers = filter_valid_destinations(
+        destinations, convert_to_international_format=True
+    )
+    assert len(valid_numbers) == 1
+    assert isinstance(valid_numbers[0], str)
+    assert valid_numbers[0].startswith("+")  # Check for international format

--- a/api/types.py
+++ b/api/types.py
@@ -1,0 +1,21 @@
+from typing import List, Optional, TypedDict
+
+
+class Recipient(TypedDict):
+    destination: str
+    format: Optional[str]
+
+
+class SendMessagePayload(TypedDict):
+    sender: str
+    to: List[Recipient]
+    text: str
+
+
+class MessageWebhookPayload(TypedDict):
+    sender: str
+    destination: str
+    status: str
+    statustime: str
+    smscount: str
+    billingref: str

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,14 +1,26 @@
-from django.urls import reverse
+import logging
+from typing import Any, List, Optional, Union
 
-from api.const import NOTIFICATION_TYPE_MOBILE
+import phonenumbers
+from django.urls import reverse
+from phonenumbers.phonenumberutil import NumberParseException
+
+from api.const import NOTIFICATION_TYPE_MOBILE, REGION
+from api.types import Recipient, SendMessagePayload
 from notification_service.settings import DEBUG, QURIIRI_REPORT_URL
 
+logger = logger = logging.getLogger(__name__)
 
-def format_destinations(recipients):
+
+def collect_destinations(
+    recipients: List[Recipient], number_type: Optional[str] = NOTIFICATION_TYPE_MOBILE
+):
+    if not number_type:
+        return [r["destination"] for r in recipients]
     return [
         r["destination"]
         for r in recipients
-        if r["format"].lower() == NOTIFICATION_TYPE_MOBILE
+        if r.get("format", "").lower() == number_type
     ]
 
 
@@ -21,3 +33,108 @@ def get_default_options(request, **kwargs):
     else:
         options["drurl"] = request.build_absolute_uri(relative_drurl)
     return options
+
+
+def filter_valid_destinations(
+    destinations: List[str], convert_to_international_format: bool = False
+) -> List[str]:
+    """
+    Filters a list of phone numbers and returns a list of valid phone numbers.
+
+    Args:
+        destinations: A list of phone numbers as strings.
+        convert_to_international_format: If True, converts valid phone numbers
+                                            to international format.
+
+    Returns:
+        A list of valid phone numbers as strings, either in their original
+        format or in international format.
+    """
+
+    valid_destinations = []
+    for destination in destinations:
+        # Pre-check for letters to prevent unwanted conversions
+        if not destination:
+            logger.warning(f"The destination was empty in {destinations}.")
+            continue
+
+        if any(char.isalpha() for char in destination):
+            logger.warning(f"Invalid phone number: {destination} (contains letters)")
+            continue
+
+        try:
+            phone_number = phonenumbers.parse(destination, REGION)
+        except NumberParseException:
+            logger.warning(f"Invalid phone number format: {destination}")
+            continue
+
+        if not phonenumbers.is_valid_number(phone_number):
+            logger.warning(f"Invalid phone number: {destination}")
+            continue
+
+        # Convert to international format if requested
+        if convert_to_international_format:
+            destination = phonenumbers.format_number(
+                phone_number, phonenumbers.PhoneNumberFormat.INTERNATIONAL
+            )
+
+        valid_destinations.append(destination)
+
+    return valid_destinations
+
+
+def validate_send_message_payload(post_data: Union[Any, SendMessagePayload]) -> None:
+    """
+    Validates the data to ensure it conforms to the SendMessagePayload structure.
+
+    Payload example
+    {
+        "sender": "Hel.fi",
+        "to": [
+            {
+                "destination": "string",
+                "format": "MOBILE",
+            },
+            {
+                "destination": "string",
+                "format": "MOBILE",
+            },
+            {
+                "destination": "string",
+                "format": "MOBILE",
+            }
+        ],
+        "text": "SMS message"
+    }
+
+    Args:
+        data: The data to validate.
+
+    Raises:
+        ValueError: If the data is not valid.
+    """
+
+    if not isinstance(post_data, dict):
+        raise ValueError("Data must be a dictionary")
+
+    if not all(key in post_data for key in ("sender", "to", "text")):
+        raise ValueError(
+            "Missing required keys: 'sender', 'to', and 'text' are required."
+        )
+
+    if not isinstance(post_data["sender"], str):
+        raise ValueError("'Sender' must be a string")
+
+    if not isinstance(post_data["to"], list) or not all(
+        isinstance(recipient, dict)
+        and "destination" in recipient
+        and isinstance(recipient["destination"], str)
+        for recipient in post_data["to"]
+    ):
+        raise ValueError(
+            "'To' must be a list of dictionaries, "
+            "each with a string 'destination' field."
+        )
+
+    if not isinstance(post_data["text"], str):
+        raise ValueError("'Text' must be a string")

--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,4 @@ factory-boy
 psycopg2
 sentry-sdk[django]
 social-auth-app-django
+phonenumberslite

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,8 @@ oauthlib==3.2.2
     #   social-auth-core
 packaging==24.1
     # via deprecation
+phonenumberslite==8.13.49
+    # via -r requirements.in
 psycopg2==2.9.10
     # via -r requirements.in
 pyasn1==0.6.1


### PR DESCRIPTION
NS-163.

Validate the input of the request to the send message view. The data needs to be structured properly so the view could fail early if any errors are raised.

Filter the list of recipient's phone numbers, so that we don't call the SMS service (Quriiri) with any totally errenous phone numbers that can never reach anybody, but are stil lbilled by the service.

Handle the errenous phone numbers softly, so that the notification service acts to the client app the same way as earlier.

Use Finnish region when parsing the phone numbers and convert the numbers into an international format. Use a list of unique numbers when finally calling the SMS service (Quriiri).

Installed phonenumberslite library
(https://pypi.org/project/phonenumberslite/) to help with the phone numbers validation.