### PR TITLE
Add is_sent and dry_run options to prune audit logs command

### DIFF
--- a/audit_log/management/commands/prune_audit_log_entries.py
+++ b/audit_log/management/commands/prune_audit_log_entries.py
@@ -7,7 +7,7 @@ from audit_log.models import AuditLogEntry
 
 
 class Command(BaseCommand):
-    help = "Prunes (deletes) AuditLog entries. Use --days to specify an age or --all to clear all entries."  # noqa: E501
+    help = "Prunes (deletes) AuditLog entries. Use --days to specify an age, --is_sent to filter by sent status, or --all to clear all entries."  # noqa: E501
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -16,18 +16,36 @@ class Command(BaseCommand):
             help="Number of days old entries should be to be deleted.",
         )
         parser.add_argument("--all", action="store_true", help="Delete all entries.")
+        parser.add_argument(
+            "--is_sent",
+            action="store_true",
+            help="Only delete entries where is_sent is True.",
+        )
 
     def handle(self, *args, **options):
+        queryset = AuditLogEntry.objects.all()
+        days = options.get("days")
+        is_sent = options.get("is_sent")
+
         if options["all"]:
-            deleted_count, _ = AuditLogEntry.objects.all().delete()
+            if days or is_sent:
+                self.stdout.write(
+                    self.style.ERROR(
+                        "The option --all cannot be used with --days or --is_sent."
+                    )
+                )
+                raise SystemExit(1)
+            deleted_count, _ = queryset.delete()
             self.stdout.write(
                 self.style.SUCCESS(
                     f"Successfully deleted all {deleted_count} AuditLog entries."
                 )
             )
-        elif options["days"]:
+            return  # Exit early after handling --all
+
+        if days:
             try:
-                days = int(options["days"])
+                days = int(days)  # Ensure days is an integer
             except ValueError:
                 self.stdout.write(
                     self.style.ERROR(
@@ -36,18 +54,30 @@ class Command(BaseCommand):
                 )
                 raise SystemExit(1)
             past = timezone.now() - timedelta(days=days)
+            queryset = queryset.filter(created_at__lte=past)
 
-            deleted_count, _ = AuditLogEntry.objects.filter(
-                created_at__lte=past
-            ).delete()
+        if is_sent:
+            queryset = queryset.filter(is_sent=True)
 
+        if not (days or is_sent):  # No filtering options provided
+            self.stdout.write(
+                self.style.ERROR(
+                    "Please specify at least one of --days, --is_sent, or --all."
+                )
+            )
+            raise SystemExit(1)
+
+        deleted_count, _ = queryset.delete()
+
+        if days:
             self.stdout.write(
                 self.style.SUCCESS(
                     f"Successfully deleted {deleted_count} AuditLog entries older than {days} days."  # noqa: E501
                 )
             )
-        else:
+        elif is_sent:
             self.stdout.write(
-                self.style.ERROR("Please specify either --days or --all.")
+                self.style.SUCCESS(
+                    f"Successfully deleted {deleted_count} sent AuditLog entries."
+                )
             )
-            raise SystemExit(1)

--- a/audit_log/tests/test_prune_logs_command.py
+++ b/audit_log/tests/test_prune_logs_command.py
@@ -82,3 +82,30 @@ class PruneAuditLogEntriesTests(TestCase):
     def test_prune_audit_log_entries_with_all_and_is_sent(self):
         with self.assertRaises(SystemExit):
             call_command("prune_audit_log_entries", all=True, is_sent=True)
+
+    def test_dry_run_with_days(self):
+        call_command("prune_audit_log_entries", days=3, dry_run=True)
+
+        # Assert that no entries were actually deleted
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry1.pk).exists())
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry2.pk).exists())
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry3.pk).exists())
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry4.pk).exists())
+
+    def test_dry_run_with_all(self):
+        call_command("prune_audit_log_entries", all=True, dry_run=True)
+
+        # Assert that no entries were actually deleted
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry1.pk).exists())
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry2.pk).exists())
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry3.pk).exists())
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry4.pk).exists())
+
+    def test_dry_run_with_days_and_is_sent(self):
+        call_command("prune_audit_log_entries", days=3, is_sent=True, dry_run=True)
+
+        # Assert that no entries were actually deleted
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry1.pk).exists())
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry2.pk).exists())
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry3.pk).exists())
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry4.pk).exists())

--- a/audit_log/tests/test_prune_logs_command.py
+++ b/audit_log/tests/test_prune_logs_command.py
@@ -15,15 +15,19 @@ class PruneAuditLogEntriesTests(TestCase):
     def setUp(self):
         # Create some AuditLog entries with different creation timestamps
 
-        self.entry1 = AuditLogEntry.objects.create(message=EMPTY_MESSAGE)
+        self.entry1 = AuditLogEntry.objects.create(message=EMPTY_MESSAGE, is_sent=True)
         self.entry1.created_at = timezone.now() - timedelta(days=5)
         self.entry1.save()
 
-        self.entry2 = AuditLogEntry.objects.create(message=EMPTY_MESSAGE)
-        self.entry2.created_at = timezone.now() - timedelta(days=2)
+        self.entry2 = AuditLogEntry.objects.create(message=EMPTY_MESSAGE, is_sent=False)
+        self.entry2.created_at = timezone.now() - timedelta(days=5)
         self.entry2.save()
 
-        self.entry3 = AuditLogEntry.objects.create(message=EMPTY_MESSAGE)
+        self.entry3 = AuditLogEntry.objects.create(message=EMPTY_MESSAGE, is_sent=True)
+        self.entry3.created_at = timezone.now() - timedelta(days=2)
+        self.entry3.save()
+
+        self.entry4 = AuditLogEntry.objects.create(message=EMPTY_MESSAGE, is_sent=True)
 
     def test_prune_audit_log_entries_with_days(self):
         # Call the command with the --days option
@@ -31,18 +35,17 @@ class PruneAuditLogEntriesTests(TestCase):
 
         # Check that the old entry is deleted
         self.assertFalse(AuditLogEntry.objects.filter(pk=self.entry1.pk).exists())
+        self.assertFalse(AuditLogEntry.objects.filter(pk=self.entry2.pk).exists())
         # Check that the recent entries are not deleted
-        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry2.pk).exists())
         self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry3.pk).exists())
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry4.pk).exists())
 
     def test_prune_audit_log_entries_with_all(self):
         # Call the command with the --all option
         call_command("prune_audit_log_entries", all=True)
 
         # Check that all entries are deleted
-        self.assertFalse(AuditLogEntry.objects.filter(pk=self.entry1.pk).exists())
-        self.assertFalse(AuditLogEntry.objects.filter(pk=self.entry2.pk).exists())
-        self.assertFalse(AuditLogEntry.objects.filter(pk=self.entry3.pk).exists())
+        self.assertListEqual(list(AuditLogEntry.objects.all()), [])
 
     def test_prune_audit_log_entries_with_no_options(self):
         # Call the command with no options
@@ -53,3 +56,29 @@ class PruneAuditLogEntriesTests(TestCase):
         # Call the command with an invalid --days option
         with self.assertRaises(SystemExit):  # Expect the command to exit with an error
             call_command("prune_audit_log_entries", days="abc")
+
+    def test_prune_audit_log_entries_with_is_sent(self):
+        call_command("prune_audit_log_entries", is_sent=True)
+
+        # Entry2 should NOT be deleted (is_sent=False)
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry2.pk).exists())
+
+        # Entry1, Entry3 and Entry4 should be deleted (is_sent=True)
+        self.assertFalse(AuditLogEntry.objects.filter(pk=self.entry1.pk).exists())
+        self.assertFalse(AuditLogEntry.objects.filter(pk=self.entry3.pk).exists())
+        self.assertFalse(AuditLogEntry.objects.filter(pk=self.entry4.pk).exists())
+
+    def test_prune_audit_log_entries_with_days_and_is_sent(self):
+        call_command("prune_audit_log_entries", days=3, is_sent=True)
+
+        # Entry1 should be deleted (old and is_sent=True)
+        self.assertFalse(AuditLogEntry.objects.filter(pk=self.entry1.pk).exists())
+        # Entry2 should NOT be deleted (old but is_sent=False)
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry2.pk).exists())
+        # Entry3 and Entry4 should NOT be deleted (recent)
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry3.pk).exists())
+        self.assertTrue(AuditLogEntry.objects.filter(pk=self.entry4.pk).exists())
+
+    def test_prune_audit_log_entries_with_all_and_is_sent(self):
+        with self.assertRaises(SystemExit):
+            call_command("prune_audit_log_entries", all=True, is_sent=True)


### PR DESCRIPTION
NS-18 NS-165.

The management command can be used to delete only the sent audit logs
that are marked with `is_sent=True`.

The management command result can be tested without committing changes
to the database using `dry_run=True`.

Refactor the management command handle because it became too complex.