### PR TITLE
NS-164 | Fix hot reload when using docker compose by using `.:/app` volume mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     env_file:
       - docker-compose.env.yaml
     volumes:
-      - djangodata:/app
+      - .:/app
       # Prevent sharing the following directories between host and container
       # to avoid ownership and/or platform issues:
       - /app/.ruff_cache
@@ -58,8 +58,6 @@ services:
     container_name: notification_service-api
 
 volumes:
-  djangodata:
-    driver: local
   pgdata:
     driver: local
 #networks:


### PR DESCRIPTION
## Description

### fix: hot reload when using docker compose by using .:/app volume mapping

Replace `djangodata` volume mapping in docker-compose.yml with mapping
the local directory i.e. `.` directory to `/app` inside the docker
container.

Do this to enable easy developing of the application locally using
docker compose with Dockerfile's development stage. Easy in this context
means that one can make changes on the fly to files on the host machine
under the `.` directory and those changes are reflected into the running
docker container without need to do anything else.

Tested that the following worked before this change (I removed all
docker images, containers, volumes and builds before testing):
 - `docker compose up --build`
 - `docker exec -it notification_service-api bash`
   - `pytest . -vv`
	 - Voila! All tests passed

Tested that the following worked after this change (I removed all
docker images, containers, volumes and builds before testing):
 - `docker compose up --build`
 - `docker exec -it notification_service-api bash`
   - `pytest . -vv`
	 - Voila! All tests passed
   - Changed a test case on the host machine to fail
   - `pytest . -vv`
	 - Voila! At least one test failed as expected because of the
	   changes made on the host machine
   - Changed the failing test case back to the working code on the host
	 machine
   - `pytest . -vv`
	 - Voila! All tests passed as expected as the code was fixed on the
	   host machine

refs NS-164

## Related

[NS-164](https://helsinkisolutionoffice.atlassian.net/browse/NS-164)

[NS-164]: https://helsinkisolutionoffice.atlassian.net/browse/NS-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Additional info

Tested using Windows 11 + Docker Desktop v4.35.1 + WSL2