### PR TITLE
NS-165 | Prune audit/delivery/Django admin logs using uwsgi cron at night

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -9,3 +9,24 @@ gid = appuser
 master = 1
 processes = 2
 threads = 2
+
+# Run Django management commands once per day at night using cron
+#
+# Format:
+# cron = <minute> <hour> <day of month> <month> <day of week> <command>
+# -1 means `*` i.e. every / any, see
+# https://uwsgi-docs.readthedocs.io/en/latest/Cron.html
+
+# Remove audit log entries that are older than 5 years
+# (5 years = 1825 days = 365 days * 5)
+cron = 0 0 -1 -1 -1 python /app/manage.py prune_audit_log_entries --days=1825
+
+# Remove audit log entries that have been sent to ElasticSearch
+cron = 15 0 -1 -1 -1 python /app/manage.py prune_audit_log_entries --is_sent
+
+# Remove Django admin logs that are older than 5 years
+# (5 years = 60 months = 12 months * 5)
+cron = 30 0 -1 -1 -1 python /app/manage.py prune_django_admin_log --months=60
+
+# Remove delivery logs that are older than 6 months
+cron = 45 0 -1 -1 -1 python /app/manage.py prune_delivery_log --months=6


### PR DESCRIPTION
## Description

### feat: prune audit/delivery/Django admin logs using uwsgi cron at night

Run Django management commands once per day at night using cron:
- Remove audit log entries that are older than 5 years
- Remove audit log entries that have been sent to ElasticSearch
- Remove Django admin logs that are older than 5 years
- Remove delivery logs that are older than 6 months

refs NS-165

## Related

[NS-165](https://helsinkisolutionoffice.atlassian.net/browse/NS-165)

## Manual testing

Tested locally by running the `production` stage of Dockerfile using docker compose i.e. `export DOCKER_TARGET=production` + `docker compose up --build` with the cronjobs in `.prod/uwsgi.ini` set to be run every 2 minutes (i.e. `-2 -1 -1 -1 -1 ...`) and creating LogEntry objects using LogEntryFactory (e.g. `LogEntryFactory.create_batch(10, action_time=timezone.now() - relativedelta(years=10))` etc).
```
notification_service-api       | Tue Nov 19 15:06:00 2024 - [uwsgi-cron] running "python /app/manage.py prune_audit_log_entries --days=1825" (pid 90)
notification_service-api       | Tue Nov 19 15:06:00 2024 - [uwsgi-cron] running "python /app/manage.py prune_audit_log_entries --is_sent" (pid 91)
notification_service-api       | Tue Nov 19 15:06:00 2024 - [uwsgi-cron] running "python /app/manage.py prune_django_admin_log --months=60" (pid 92)
notification_service-api       | Tue Nov 19 15:06:00 2024 - [uwsgi-cron] running "python /app/manage.py prune_delivery_log --months=6" (pid 93)
notification_service-api       | Successfully deleted 0 sent AuditLog entries.
notification_service-api       | Successfully deleted 0 AuditLog entries older than 1825 days.
notification_service-api       | Deleted 0 delivery logs created at least 6 months ago
notification_service-api       | Deleted 217 Django admin logs created at least 60 months ago
notification_service-api       | [uwsgi-cron] command "python /app/manage.py prune_audit_log_entries --days=1825" running with pid 90 exited after 2 second(s)
notification_service-api       | [uwsgi-cron] command "python /app/manage.py prune_audit_log_entries --is_sent" running with pid 91 exited after 2 second(s)
notification_service-api       | [uwsgi-cron] command "python /app/manage.py prune_django_admin_log --months=60" running with pid 92 exited after 2 second(s)
notification_service-api       | [uwsgi-cron] command "python /app/manage.py prune_delivery_log --months=6" running with pid 93 exited after 2 second(s)
```
☝️ That's what showed up in the terminal that was running `docker compose up --build`. So it shows that Django admin logs (i.e. LogEntry objects) were pruned.

[NS-165]: https://helsinkisolutionoffice.atlassian.net/browse/NS-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ