### PR TITLE
NS-178 | Remove cronjobs from uwsgi.ini → OpenShift is wanted for cronjobs instead

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -9,24 +9,3 @@ gid = appuser
 master = 1
 processes = 2
 threads = 2
-
-# Run Django management commands once per day at night using cron
-#
-# Format:
-# cron = <minute> <hour> <day of month> <month> <day of week> <command>
-# -1 means `*` i.e. every / any, see
-# https://uwsgi-docs.readthedocs.io/en/latest/Cron.html
-
-# Remove audit log entries that are older than 5 years
-# (5 years = 1825 days = 365 days * 5)
-cron = 0 0 -1 -1 -1 python /app/manage.py prune_audit_log_entries --days=1825
-
-# Remove audit log entries that have been sent to ElasticSearch
-cron = 15 0 -1 -1 -1 python /app/manage.py prune_audit_log_entries --is_sent
-
-# Remove Django admin logs that are older than 5 years
-# (5 years = 60 months = 12 months * 5)
-cron = 30 0 -1 -1 -1 python /app/manage.py prune_django_admin_log --months=60
-
-# Remove delivery logs that are older than 6 months
-cron = 45 0 -1 -1 -1 python /app/manage.py prune_delivery_log --months=6


### PR DESCRIPTION
## Description

### fix: remove cronjobs from uwsgi.ini, OpenShift is wanted for cronjobs

This only removes the cronjobs added to uwsgi.ini in PR #74 

These cronjobs need to be added to the OpenShift / DevOps / Platta side.

refs NS-178

## Related

- [NS-178](https://helsinkisolutionoffice.atlassian.net/browse/NS-178) "Move audit logs to ElasticSearch periodically"
- https://github.com/City-of-Helsinki/notification-service-api/pull/74 The cronjobs added previously to uwsgi.ini

[NS-178]: https://helsinkisolutionoffice.atlassian.net/browse/NS-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ