### PR TITLE
fix(release-please): update uv.lock TOML JSONPath

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,11 +20,10 @@
         { "type": "ci", "section": "Continuous Integration", "hidden": true }
       ],
       "extra-files": [
-        {"path": "pyproject.toml", "type": "toml"},
         {
           "path": "uv.lock",
           "type": "toml",
-          "jsonpath": "$.package[?(@.name=='notification-service')].version"
+          "jsonpath": "$.package[?(@.name.value=='notification-service')].version"
         }
       ]
     }


### PR DESCRIPTION
Updates:
- Fix the uv.lock TOML JSONPath from @.name to @.name.value, which matches release-please’s tagged TOML parser.
- Remove the redundant pyproject.toml extra-files entry. The python release type already updates pyproject.toml.

Refs: [NS-209](https://helsinkisolutionoffice.atlassian.net/browse/NS-209)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified release tracking configuration for project files.
  * Updated how lockfile and project metadata are monitored, making the setup cleaner and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[NS-209]: https://helsinkisolutionoffice.atlassian.net/browse/NS-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ